### PR TITLE
add support for BSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - A tiny library (8kB)
 - with minimal public API (3 classes, 6 methods, 21 fields)
 - for convenient access to standardized directories
-- on Linux, Windows (≥ 7) and macOS
+- on Linux, Windows (≥ 7), macOS and BSD
 - running on the JVM
 
 The library provides the location of directories by leveraging the mechanisms defined by
@@ -57,9 +57,9 @@ System.out.println(myProjConfigDir); // "/home/my_user_name/.config/my-project/"
 The intended use-case for `BaseDirectories` is to query the paths of standard folders
 that have been defined according to the conventions of operating system the library is running on.
 
-If you want to compute the location of cache, config or data folders for your own application or project, use `ProjectDirectories` instead. 
+If you want to compute the location of cache, config or data folders for your own application or project, use `ProjectDirectories` instead.
 
-| Static field name | Value on Linux                                    | Value on Windows                              | Value on macOS                       |
+| Static field name | Value on Linux / BSD                              | Value on Windows                              | Value on macOS                       |
 | ----------------- | ------------------------------------------------- | --------------------------------------------- | ------------------------------------ |
 | `homeDir`         | `$HOME`                                           | `{SpecialFolder.UserProfile}`                 | `$HOME`                              |
 | `cacheDir`        | `$XDG_CACHE_DIR`  or `~/.cache/`                  | `{SpecialFolder.LocalApplicationData}/cache/` | `$HOME/Library/Caches/`              |
@@ -81,9 +81,9 @@ If you want to compute the location of cache, config or data folders for your ow
 ### `ProjectDirectories`
 
 The intended use-case for `BaseDirectories` is to compute the location of cache, config or data folders for your own application or project,
-which are derived from the standardized directories. 
+which are derived from the standardized directories.
 
-| Instance field name     | Value on Linux                                                           | Value on Windows                                                | Value on macOS                                         |
+| Instance field name     | Value on Linux / BSD                                                     | Value on Windows                                                | Value on macOS                                         |
 | ----------------------- | ------------------------------------------------------------------------ | --------------------------------------------------------------- | ------------------------------------------------------ |
 | `projectCacheDir`       | `$XDG_CONFIG_DIR/_yourprojectname_` or `~/.config/_yourprojectname_/`    | `{SpecialFolder.LocalApplicationData}/cache/_yourprojectname_/` | `$HOME/Library/Caches/_yourprojectname_/`         |
 | `projectConfigDir`      | `$XDG_CACHE_DIR/_yourprojectname_`  or `~/.cache/_yourprojectname_/`     | `{SpecialFolder.ApplicationData}/_yourprojectname_/`            | `$HOME/Library/Preferences/_yourprojectname_/`              |

--- a/src/main/java/io/github/soc/directories/BaseDirectories.java
+++ b/src/main/java/io/github/soc/directories/BaseDirectories.java
@@ -34,6 +34,7 @@ public final class BaseDirectories {
   static {
     switch (operatingSystem) {
       case LIN:
+      case BSD:
         homeDir        = System.getenv("HOME");
         cacheDir       = defaultIfNullOrEmpty(System.getenv("XDG_CACHE_HOME"),  homeDir, "/.cache/");
         configDir      = defaultIfNullOrEmpty(System.getenv("XDG_CONFIG_HOME"), homeDir, "/.config/");

--- a/src/main/java/io/github/soc/directories/ProjectDirectories.java
+++ b/src/main/java/io/github/soc/directories/ProjectDirectories.java
@@ -36,6 +36,7 @@ public final class ProjectDirectories {
     String projectDataRoamingDir;
     switch (operatingSystem) {
       case LIN:
+      case BSD:
         homeDir               = System.getenv("HOME");
         projectCacheDir       = defaultIfNullOrEmpty(System.getenv("XDG_CACHE_HOME"),  homeDir + "/.cache/",       value + "/");
         projectConfigDir      = defaultIfNullOrEmpty(System.getenv("XDG_CONFIG_HOME"), homeDir + "/.config/",      value + "/");
@@ -65,6 +66,7 @@ public final class ProjectDirectories {
     String name;
     switch (operatingSystem) {
       case LIN:
+      case BSD:
         name = stripQualification(qualifiedProjectName).toLowerCase(Locale.ENGLISH).trim();
         break;
       case MAC:
@@ -83,6 +85,7 @@ public final class ProjectDirectories {
     String name;
     switch (operatingSystem) {
       case LIN:
+      case BSD:
         name = trimAndReplaceSpacesWithHyphensThenLowerCase(projectName);
         break;
       case MAC:
@@ -100,6 +103,7 @@ public final class ProjectDirectories {
   private static final char LIN = 'l';
   private static final char MAC = 'm';
   private static final char WIN = 'w';
+  private static final char BSD = 'b';
 
   static {
     final String os = operatingSystemName.toLowerCase(Locale.ENGLISH);
@@ -109,6 +113,8 @@ public final class ProjectDirectories {
       operatingSystem = MAC;
     else if (os.contains("win"))
       operatingSystem = WIN;
+    else if (os.contains("bsd"))
+      operatingSystem = BSD;
     else
       throw new UnsupportedOperatingSystemException("Base directories are not supported on " + operatingSystemName);
   };

--- a/src/main/java/io/github/soc/directories/Util.java
+++ b/src/main/java/io/github/soc/directories/Util.java
@@ -15,6 +15,7 @@ final class Util {
   static final char LIN = 'l';
   static final char MAC = 'm';
   static final char WIN = 'w';
+  static final char BSD = 'b';
 
   static {
     final String os = operatingSystemName.toLowerCase(Locale.ENGLISH);
@@ -24,10 +25,12 @@ final class Util {
       operatingSystem = MAC;
     else if (os.contains("windows"))
       operatingSystem = WIN;
+    else if (os.contains("bsd"))
+      operatingSystem = BSD;
     else
       throw new UnsupportedOperatingSystemException("Base directories are not supported on " + operatingSystemName);
   }
-  
+
   static void requireNonNull(Object value) {
     if (value == null)
       throw new NullPointerException();


### PR DESCRIPTION
BSD have the same file-system layout for user-specific
configuration / cache files like Linux.

This commit also uses the Linux implementation for BSD.

I don't merge Linux and BSD under the same identifier,
if they need to be treated differently later.